### PR TITLE
ops(nuget): fix vulnerable transitive package Azure.Identity

### DIFF
--- a/DataImport.Web/DataImport.Web.csproj
+++ b/DataImport.Web/DataImport.Web.csproj
@@ -33,6 +33,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="6.0.5" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="6.0.3" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.10" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.7" />
     <PackageReference Include="IdentityModel" Version="6.2.0" />


### PR DESCRIPTION
Installed the latest installed version 1.10.4 overrding the vulnerable implicitly installed version 1.6.0